### PR TITLE
v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2020-06-15
+
+### Added
 - 'exists' function - check if an object exists at a specific S3 key
 - Unit tests!
 

--- a/river/__version__.py
+++ b/river/__version__.py
@@ -1,6 +1,6 @@
 __title__ = "river"
 __description__ = "A Python-to-S3 interface with added convenience features."
 __url__ = "https://github.com/neighborhoods/river"
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"


### PR DESCRIPTION
Releasing v0.2 to allow for usage of `exists` fn in `honeycomb` releases.

Added:
- 'exists' function - check if an object exists at a specific S3 key
- Unit tests!