### PR TITLE
Fix recursive listing grepping improperly

### DIFF
--- a/river/s3_list.py
+++ b/river/s3_list.py
@@ -32,7 +32,7 @@ def list_objects(path='',
 
     if not recursive:
         keys = list(
-            {re.match(path + r'[\w. ]*/?', key).group() for key in keys}
+            {re.match(path + r'[^/]*/?', key).group() for key in keys}
         )
     if '/' in path and not include_prefix:
         keys = [key[path.rfind('/') + 1:] for key in keys]


### PR DESCRIPTION
Frankie pointed out that the 'recursive' option in `list_objects` would truncate keys in an unintended way. This is because the regexp pattern I was matching keys with was not inclusive enough in regard to allowed characters in S3 keys. Just before starting a journey to build a regexp pattern that includes all allowed characters allowed in S3 keys, I realized that any objects present in S3 inherently must already have a valid key. So, I simply match against any number of any character other than `/` and the function works exactly as intended.