### PR TITLE
Bugfix: kwargs for __write_parquet

### DIFF
--- a/river/storage_formats.py
+++ b/river/storage_formats.py
@@ -155,7 +155,7 @@ def _write_parquet(obj, tmpfile, index=False, *args, **kwargs):
         raise TypeError('Storage format of \'pq\'/\'parquet\' can only '
                         'be used with DataFrames.')
 
-    obj.to_parquet(tmpfile.name, index=index)
+    obj.to_parquet(tmpfile.name, index=index, *args, **kwargs)
 
 
 pq = {


### PR DESCRIPTION
This didn't actually affect any functionality, but while experimenting with different Parquet libraries (`pyarrow` vs `fastparquet`), I discovered that the Parquet writing functionality of `river` is missing kwarg passthrough.