### PR TITLE
Adding deploy flag to CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ boto3 = "==1.13.11"
 pandas = "==1.0.3"
 pyarrow = "==0.17.1"
 pandavro = "==1.5.2"
-pytest-cov = "*"
 
 [requires]
 python_version = "3.7"

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,7 @@ setup(
         'boto3>=1.10.0',
         'pandas>=1.0.0',
         'pandavro>=1.5.1',
-        'pyarrow>=0.17.0',
-        'pytest-cov==*'
+        'pyarrow>=0.17.0'
     ],
     cmdclass={
         'upload': UploadCommand,


### PR DESCRIPTION
Adding deploy flag to CI.

The locking operation of Pipenv takes a very long time with the NHDS private PyPi. This will allow users to use Pipenv's `--skip-lock` flag to skip the locking operation, allowing for much faster iteration time. Adding the `--deploy` flag here will make sure that the `Pipfile.lock` is up-to-date with any changes made to the `Pipfile`.